### PR TITLE
Search filter for deprecated entities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>edu.stanford.protege</groupId>
     <artifactId>webprotege-backend-api</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <guava.version>28.0</guava.version>

--- a/src/main/java/edu/stanford/protege/webprotege/search/DeprecatedEntitiesTreatment.java
+++ b/src/main/java/edu/stanford/protege/webprotege/search/DeprecatedEntitiesTreatment.java
@@ -1,0 +1,8 @@
+package edu.stanford.protege.webprotege.search;
+
+public enum DeprecatedEntitiesTreatment {
+
+    INCLUDE_DEPRECATED_ENTITIES,
+
+    EXCLUDE_DEPRECATED_ENTITIES;
+}

--- a/src/main/java/edu/stanford/protege/webprotege/search/PerformEntitySearchAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/search/PerformEntitySearchAction.java
@@ -36,7 +36,8 @@ public record PerformEntitySearchAction(
         @JsonProperty("langTagFilter") @Nonnull LangTagFilter langTagFilter,
         @JsonProperty("searchFilters") @Nonnull ImmutableList<EntitySearchFilter> searchFilters,
         @JsonProperty("pageRequest") @Nonnull PageRequest pageRequest,
-        @JsonProperty("resultsSetFilter") @Nullable EntityMatchCriteria resultsSetFilter) implements ProjectAction<PerformEntitySearchResult>, HasProjectId {
+        @JsonProperty("resultsSetFilter") @Nullable EntityMatchCriteria resultsSetFilter,
+        @JsonProperty("deprecatedEntitiesTreatment") DeprecatedEntitiesTreatment deprecatedEntitiesTreatment) implements ProjectAction<PerformEntitySearchResult>, HasProjectId {
 
     public static final String CHANNEL = "webprotege.search.PerformEntitySearch";
 
@@ -46,7 +47,8 @@ public record PerformEntitySearchAction(
                                      @JsonProperty("langTagFilter") @Nonnull LangTagFilter langTagFilter,
                                      @JsonProperty("searchFilters") @Nonnull ImmutableList<EntitySearchFilter> searchFilters,
                                      @JsonProperty("pageRequest") @Nonnull PageRequest pageRequest,
-                                     @JsonProperty("resultsSetFilter") @Nullable EntityMatchCriteria resultsSetFilter) {
+                                     @JsonProperty("resultsSetFilter") @Nullable EntityMatchCriteria resultsSetFilter,
+                                     @JsonProperty("deprecatedEntitiesTreatment") DeprecatedEntitiesTreatment deprecatedEntitiesTreatment) {
         this.projectId = requireNonNull(projectId);
         this.searchString = requireNonNull(searchString);
         this.entityTypes = requireNonNullElse(entityTypes, Collections.emptySet());
@@ -54,10 +56,11 @@ public record PerformEntitySearchAction(
         this.searchFilters = requireNonNullElse(searchFilters, ImmutableList.of());
         this.pageRequest = requireNonNullElse(pageRequest, PageRequest.requestFirstPage());
         this.resultsSetFilter = requireNonNullElse(resultsSetFilter, EntityTypeIsOneOfCriteria.get(ImmutableSet.copyOf(entityTypes)));
+        this.deprecatedEntitiesTreatment = requireNonNullElse(deprecatedEntitiesTreatment, DeprecatedEntitiesTreatment.INCLUDE_DEPRECATED_ENTITIES);
     }
 
     public PerformEntitySearchAction(@Nonnull ProjectId projectId, @Nonnull String searchString, @Nonnull Set<EntityType<?>> entityTypes, @Nonnull LangTagFilter langTagFilter, @Nonnull ImmutableList<EntitySearchFilter> searchFilters, @Nonnull PageRequest pageRequest) {
-        this(projectId, searchString, entityTypes, langTagFilter, searchFilters, pageRequest, null);
+        this(projectId, searchString, entityTypes, langTagFilter, searchFilters, pageRequest, null, DeprecatedEntitiesTreatment.INCLUDE_DEPRECATED_ENTITIES);
     }
 
     @Override

--- a/src/test/java/edu/stanford/protege/webprotege/search/PerformEntitySearch_Serialization_TestCase.java
+++ b/src/test/java/edu/stanford/protege/webprotege/search/PerformEntitySearch_Serialization_TestCase.java
@@ -26,7 +26,8 @@ public class PerformEntitySearch_Serialization_TestCase {
                 "Test", Collections.emptySet(),
                 LangTagFilter.get(ImmutableSet.of()), ImmutableList.of(),
                 PageRequest.requestFirstPage(),
-                null);
+                null,
+                DeprecatedEntitiesTreatment.EXCLUDE_DEPRECATED_ENTITIES);
 
     }
 


### PR DESCRIPTION
Added a flag to the PerformEntitySearchAction that allows deprecated entities to be included or excluded in search results.