### PR TITLE
Pin @JsonProperty on FRAGILE wire DTO record components (#52)

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/app/GetApplicationSettingsResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/app/GetApplicationSettingsResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.app;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.dispatch.Result;
 
@@ -11,6 +12,6 @@ import edu.stanford.protege.webprotege.dispatch.Result;
 
 
 @JsonTypeName("webprotege.application.GetApplicationSettings")
-public record GetApplicationSettingsResult(ApplicationSettings settings) implements Result {
+public record GetApplicationSettingsResult(@JsonProperty("settings") ApplicationSettings settings) implements Result {
 
 }

--- a/src/main/java/edu/stanford/protege/webprotege/change/GetProjectChangesAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/change/GetProjectChangesAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.change;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.PageRequest;
 import edu.stanford.protege.webprotege.common.ProjectId;
@@ -16,9 +17,9 @@ import java.util.Optional;
  * 24/02/15
  */
 @JsonTypeName("webprotege.history.GetProjectChanges")
-public record GetProjectChangesAction(@Nonnull ProjectId projectId,
-                                     @Nonnull Optional<OWLEntity> subject,
-                                     @Nonnull PageRequest pageRequest) implements ProjectAction<GetProjectChangesResult> {
+public record GetProjectChangesAction(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                     @JsonProperty("subject") @Nonnull Optional<OWLEntity> subject,
+                                     @JsonProperty("pageRequest") @Nonnull PageRequest pageRequest) implements ProjectAction<GetProjectChangesResult> {
 
     public static final String CHANNEL = "webprotege.history.GetProjectChanges";
 

--- a/src/main/java/edu/stanford/protege/webprotege/entity/CreateClassesAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/entity/CreateClassesAction.java
@@ -1,6 +1,7 @@
 package edu.stanford.protege.webprotege.entity;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableSet;
@@ -19,16 +20,20 @@ import org.semanticweb.owlapi.model.OWLClass;
  */
 @JsonTypeName("webprotege.entities.CreateClasses")
 @JsonClassDescription("Represents a request to create OWL classes in a specified project")
-public record CreateClassesAction(ChangeRequestId changeRequestId,
+public record CreateClassesAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                  @JsonProperty("projectId")
                                   @JsonPropertyDescription("The id of the project where the classes will be created")
                                   ProjectId projectId,
+                                  @JsonProperty("sourceText")
                                   @JsonPropertyDescription("""
                                           The source text that contains the user supplied names for the classes.
 
                                           Multiple user-supplied class names should be separated with a new line.""")
                                   String sourceText,
+                                  @JsonProperty("langTag")
                                   @JsonPropertyDescription("The language tag that should be used for the labels of the created classes")
                                   String langTag,
+                                  @JsonProperty("parents")
                                   @JsonPropertyDescription("""
                                           A set of classes that the created classes will be subclasses of.
 

--- a/src/main/java/edu/stanford/protege/webprotege/entity/CreateClassesResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/entity/CreateClassesResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
@@ -14,7 +15,7 @@ import edu.stanford.protege.webprotege.dispatch.Result;
  * Date: 22/02/2013
  */
 @JsonTypeName("webprotege.entities.CreateClasses")
-public record CreateClassesResult(ChangeRequestId changeRequestId,
-                                  ProjectId projectId,
-                                  ImmutableSet<EntityNode> entities) implements Result, Response {
+public record CreateClassesResult(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                  @JsonProperty("projectId") ProjectId projectId,
+                                  @JsonProperty("entities") ImmutableSet<EntityNode> entities) implements Result, Response {
 }

--- a/src/main/java/edu/stanford/protege/webprotege/entity/CreateDataPropertiesAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/entity/CreateDataPropertiesAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
@@ -17,11 +18,11 @@ import javax.annotation.Nonnull;
  * Date: 25/03/2013
  */
 @JsonTypeName("webprotege.entities.CreateDataProperties")
-public record CreateDataPropertiesAction(@Nonnull ChangeRequestId changeRequestId,
-                                         @Nonnull ProjectId projectId,
-                                         @Nonnull String sourceText,
-                                         @Nonnull String langTag,
-                                         ImmutableSet<OWLDataProperty> parents) implements ProjectAction<CreateDataPropertiesResult>, ContentChangeRequest {
+public record CreateDataPropertiesAction(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                         @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                         @JsonProperty("sourceText") @Nonnull String sourceText,
+                                         @JsonProperty("langTag") @Nonnull String langTag,
+                                         @JsonProperty("parents") ImmutableSet<OWLDataProperty> parents) implements ProjectAction<CreateDataPropertiesResult>, ContentChangeRequest {
 
     public static final String CHANNEL = "webprotege.entities.CreateDataProperties";
 

--- a/src/main/java/edu/stanford/protege/webprotege/entity/CreateDataPropertiesResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/entity/CreateDataPropertiesResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
@@ -13,7 +14,7 @@ import edu.stanford.protege.webprotege.dispatch.Result;
  * Date: 25/03/2013
  */
 @JsonTypeName("webprotege.entities.CreateDataProperties")
-public record CreateDataPropertiesResult(ProjectId projectId,
-                                         ImmutableSet<EntityNode> entities,
-                                         ChangeRequestId changeRequestId) implements Result {
+public record CreateDataPropertiesResult(@JsonProperty("projectId") ProjectId projectId,
+                                         @JsonProperty("entities") ImmutableSet<EntityNode> entities,
+                                         @JsonProperty("changeRequestId") ChangeRequestId changeRequestId) implements Result {
 }

--- a/src/main/java/edu/stanford/protege/webprotege/entity/CreateNamedIndividualsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/entity/CreateNamedIndividualsAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
@@ -17,11 +18,11 @@ import javax.annotation.Nonnull;
  * Date: 12/09/2013
  */
 @JsonTypeName("webprotege.entities.CreateNamedIndividuals")
-public record CreateNamedIndividualsAction(@Nonnull ChangeRequestId changeRequestId,
-                                           @Nonnull ProjectId projectId,
-                                           @Nonnull String sourceText,
-                                           @Nonnull String langTag,
-                                           @Nonnull ImmutableSet<OWLClass> types) implements ProjectAction<CreateNamedIndividualsResult>, ContentChangeRequest {
+public record CreateNamedIndividualsAction(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                           @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                           @JsonProperty("sourceText") @Nonnull String sourceText,
+                                           @JsonProperty("langTag") @Nonnull String langTag,
+                                           @JsonProperty("types") @Nonnull ImmutableSet<OWLClass> types) implements ProjectAction<CreateNamedIndividualsResult>, ContentChangeRequest {
 
     public static final String CHANNEL = "webprotege.entities.CreateNamedIndividuals";
 

--- a/src/main/java/edu/stanford/protege/webprotege/entity/CreateNamedIndividualsResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/entity/CreateNamedIndividualsResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
@@ -15,7 +16,7 @@ import javax.annotation.Nonnull;
  * Date: 12/09/2013
  */
 @JsonTypeName("webprotege.entities.CreateNamedIndividuals")
-public record CreateNamedIndividualsResult(@Nonnull ProjectId projectId,
-                                           ImmutableSet<EntityNode> entities,
-                                           ChangeRequestId changeRequestId) implements Result {
+public record CreateNamedIndividualsResult(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                           @JsonProperty("entities") ImmutableSet<EntityNode> entities,
+                                           @JsonProperty("changeRequestId") ChangeRequestId changeRequestId) implements Result {
 }

--- a/src/main/java/edu/stanford/protege/webprotege/entity/CreateObjectPropertiesAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/entity/CreateObjectPropertiesAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
@@ -17,11 +18,11 @@ import javax.annotation.Nonnull;
  * Date: 25/03/2013
  */
 @JsonTypeName("webprotege.entities.CreateObjectProperties")
-public record CreateObjectPropertiesAction(@Nonnull ChangeRequestId changeRequestId,
-                                           @Nonnull ProjectId projectId,
-                                           @Nonnull String sourceText,
-                                           @Nonnull String langTag,
-                                           @Nonnull ImmutableSet<OWLObjectProperty> parents) implements ProjectAction<CreateObjectPropertiesResult>, ContentChangeRequest {
+public record CreateObjectPropertiesAction(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                           @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                           @JsonProperty("sourceText") @Nonnull String sourceText,
+                                           @JsonProperty("langTag") @Nonnull String langTag,
+                                           @JsonProperty("parents") @Nonnull ImmutableSet<OWLObjectProperty> parents) implements ProjectAction<CreateObjectPropertiesResult>, ContentChangeRequest {
 
     public static final String CHANNEL = "webprotege.entities.CreateObjectProperties";
 

--- a/src/main/java/edu/stanford/protege/webprotege/entity/DeleteEntitiesAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/entity/DeleteEntitiesAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
@@ -16,9 +17,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 9 May 2017
  */
 @JsonTypeName("webprotege.entities.DeleteEntities")
-public record DeleteEntitiesAction(ChangeRequestId changeRequestId,
-                                   ProjectId projectId,
-                                   ImmutableSet<OWLEntity> entities) implements ProjectAction<DeleteEntitiesResult>, ContentChangeRequest {
+public record DeleteEntitiesAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                   @JsonProperty("projectId") ProjectId projectId,
+                                   @JsonProperty("entities") ImmutableSet<OWLEntity> entities) implements ProjectAction<DeleteEntitiesResult>, ContentChangeRequest {
 
     public static final String CHANNEL = "webprotege.entities.DeleteEntities";
 
@@ -27,7 +28,9 @@ public record DeleteEntitiesAction(ChangeRequestId changeRequestId,
         return CHANNEL;
     }
 
-    public DeleteEntitiesAction(ChangeRequestId changeRequestId, ProjectId projectId, ImmutableSet<OWLEntity> entities) {
+    public DeleteEntitiesAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                @JsonProperty("projectId") ProjectId projectId,
+                                @JsonProperty("entities") ImmutableSet<OWLEntity> entities) {
         this.changeRequestId = checkNotNull(changeRequestId);
         this.projectId = checkNotNull(projectId);
         this.entities = checkNotNull(entities);

--- a/src/main/java/edu/stanford/protege/webprotege/entity/DeleteEntitiesResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/entity/DeleteEntitiesResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.protege.webprotege.dispatch.Result;
@@ -11,5 +12,5 @@ import org.semanticweb.owlapi.model.OWLEntity;
  * 9 May 2017
  */
 @JsonTypeName("webprotege.entities.DeleteEntities")
-public record DeleteEntitiesResult(ImmutableSet<OWLEntity> deletedEntities) implements Result {
+public record DeleteEntitiesResult(@JsonProperty("deletedEntities") ImmutableSet<OWLEntity> deletedEntities) implements Result {
 }

--- a/src/main/java/edu/stanford/protege/webprotege/entity/GetDeprecatedEntitiesResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/entity/GetDeprecatedEntitiesResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.Page;
 import edu.stanford.protege.webprotege.dispatch.Result;
@@ -12,6 +13,6 @@ import edu.stanford.protege.webprotege.dispatch.Result;
 
 
 @JsonTypeName("webprotege.entities.GetDeprecatedEntities")
-public record GetDeprecatedEntitiesResult(Page<OWLEntityData> entities) implements Result {
+public record GetDeprecatedEntitiesResult(@JsonProperty("entities") Page<OWLEntityData> entities) implements Result {
 
 }

--- a/src/main/java/edu/stanford/protege/webprotege/entity/LookupEntitiesAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/entity/LookupEntitiesAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.ProjectAction;
@@ -17,7 +18,8 @@ import edu.stanford.protege.webprotege.dispatch.ProjectAction;
  * @throws  NullPointerException if any parameters are {@code null}.
  */
 @JsonTypeName("webprotege.entities.LookupEntities")
-public record LookupEntitiesAction(ProjectId projectId, EntityLookupRequest entityLookupRequest) implements ProjectAction<LookupEntitiesResult> {
+public record LookupEntitiesAction(@JsonProperty("projectId") ProjectId projectId,
+                                   @JsonProperty("entityLookupRequest") EntityLookupRequest entityLookupRequest) implements ProjectAction<LookupEntitiesResult> {
 
     public static final String CHANNEL = "webprotege.entities.LookupEntities";
 

--- a/src/main/java/edu/stanford/protege/webprotege/entity/LookupEntitiesResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/entity/LookupEntitiesResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.dispatch.Result;
 
@@ -14,6 +15,6 @@ import java.util.List;
 
 
 @JsonTypeName("webprotege.entities.LookupEntities")
-public record LookupEntitiesResult(List<EntityLookupResult> results) implements Result {
+public record LookupEntitiesResult(@JsonProperty("results") List<EntityLookupResult> results) implements Result {
 
 }

--- a/src/main/java/edu/stanford/protege/webprotege/hierarchy/GetHierarchyPathsToRootResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/hierarchy/GetHierarchyPathsToRootResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.hierarchy;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.dispatch.Result;
 import edu.stanford.protege.webprotege.entity.EntityNode;
@@ -12,6 +13,6 @@ import java.util.Collection;
 
 
 @JsonTypeName("webprotege.hierarchies.GetHierarchyPathsToRoot")
-public record GetHierarchyPathsToRootResult(Collection<Path<GraphNode<EntityNode>>> paths) implements Result {
+public record GetHierarchyPathsToRootResult(@JsonProperty("paths") Collection<Path<GraphNode<EntityNode>>> paths) implements Result {
 
 }

--- a/src/main/java/edu/stanford/protege/webprotege/hierarchy/GetHierarchyRootsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/hierarchy/GetHierarchyRootsAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.hierarchy;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.ProjectAction;
@@ -12,7 +13,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Matthew Horridge Stanford Center for Biomedical Informatics Research 30 Nov 2017
  */
 @JsonTypeName("webprotege.hierarchies.GetHierarchyRoots")
-public record GetHierarchyRootsAction(@Nonnull ProjectId projectId, @Nonnull HierarchyDescriptor hierarchyDescriptor) implements ProjectAction<GetHierarchyRootsResult> {
+public record GetHierarchyRootsAction(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                      @JsonProperty("hierarchyDescriptor") @Nonnull HierarchyDescriptor hierarchyDescriptor) implements ProjectAction<GetHierarchyRootsResult> {
 
     public static final String CHANNEL = "webprotege.hierarchies.GetHierarchyRoots";
 
@@ -21,7 +23,8 @@ public record GetHierarchyRootsAction(@Nonnull ProjectId projectId, @Nonnull Hie
         return CHANNEL;
     }
 
-    public GetHierarchyRootsAction(@Nonnull ProjectId projectId, @Nonnull HierarchyDescriptor hierarchyDescriptor) {
+    public GetHierarchyRootsAction(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                   @JsonProperty("hierarchyDescriptor") @Nonnull HierarchyDescriptor hierarchyDescriptor) {
         this.projectId = checkNotNull(projectId);
         this.hierarchyDescriptor = checkNotNull(hierarchyDescriptor);
     }

--- a/src/main/java/edu/stanford/protege/webprotege/issues/CreateEntityDiscussionThreadResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/issues/CreateEntityDiscussionThreadResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.issues;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableList;
 import edu.stanford.protege.webprotege.dispatch.Result;
@@ -12,5 +13,5 @@ import javax.annotation.Nonnull;
  * 6 Oct 2016
  */
 @JsonTypeName("webprotege.discussions.CreateEntityDiscussionThread")
-public record CreateEntityDiscussionThreadResult(@Nonnull ImmutableList<EntityDiscussionThread> threads) implements Result {
+public record CreateEntityDiscussionThreadResult(@JsonProperty("threads") @Nonnull ImmutableList<EntityDiscussionThread> threads) implements Result {
 }

--- a/src/main/java/edu/stanford/protege/webprotege/issues/GetEntityDiscussionThreadsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/issues/GetEntityDiscussionThreadsAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.issues;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.ProjectAction;
@@ -13,7 +14,8 @@ import javax.annotation.Nonnull;
  * 5 Oct 2016
  */
 @JsonTypeName("webprotege.discussions.GetEntityDiscussionThreads")
-public record GetEntityDiscussionThreadsAction(@Nonnull ProjectId projectId, @Nonnull OWLEntity entity) implements ProjectAction<GetEntityDiscussionThreadsResult> {
+public record GetEntityDiscussionThreadsAction(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                               @JsonProperty("entity") @Nonnull OWLEntity entity) implements ProjectAction<GetEntityDiscussionThreadsResult> {
 
     public static final String CHANNEL = "webprotege.discussions.GetEntityDiscussionThreads";
 

--- a/src/main/java/edu/stanford/protege/webprotege/issues/GetEntityDiscussionThreadsResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/issues/GetEntityDiscussionThreadsResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.issues;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableList;
 import edu.stanford.protege.webprotege.dispatch.Result;
@@ -13,6 +14,6 @@ import edu.stanford.protege.webprotege.entity.OWLEntityData;
 
 
 @JsonTypeName("webprotege.discussions.GetEntityDiscussionThreads")
-public record GetEntityDiscussionThreadsResult(OWLEntityData entity,
-                                               ImmutableList<EntityDiscussionThread> threads) implements Result {
+public record GetEntityDiscussionThreadsResult(@JsonProperty("entity") OWLEntityData entity,
+                                               @JsonProperty("threads") ImmutableList<EntityDiscussionThread> threads) implements Result {
 }

--- a/src/main/java/edu/stanford/protege/webprotege/issues/SetDiscussionThreadStatusResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/issues/SetDiscussionThreadStatusResult.java
@@ -1,6 +1,7 @@
 package edu.stanford.protege.webprotege.issues;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.dispatch.Result;
 
@@ -12,7 +13,7 @@ import javax.annotation.Nonnull;
  * 12 Oct 2016
  */
 @JsonTypeName("webprotege.discussions.SetDiscussionThreadStatus")
-public record SetDiscussionThreadStatusResult(@Nonnull ThreadId threadId,
-                                             @Nonnull Status result) implements Result {
+public record SetDiscussionThreadStatusResult(@JsonProperty("threadId") @Nonnull ThreadId threadId,
+                                             @JsonProperty("result") @Nonnull Status result) implements Result {
 
 }

--- a/src/main/java/edu/stanford/protege/webprotege/lang/GetProjectLangTagsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/lang/GetProjectLangTagsAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.lang;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.ProjectAction;
@@ -12,7 +13,7 @@ import javax.annotation.Nonnull;
  * 2020-04-26
  */
 @JsonTypeName("webprotege.projects.GetProjectLangTags")
-public record GetProjectLangTagsAction(ProjectId projectId) implements ProjectAction<GetProjectLangTagsResult> {
+public record GetProjectLangTagsAction(@JsonProperty("projectId") ProjectId projectId) implements ProjectAction<GetProjectLangTagsResult> {
 
     public static final String CHANNEL = "webprotege.projects.GetProjectLangTags";
 

--- a/src/main/java/edu/stanford/protege/webprotege/lang/GetProjectLangTagsResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/lang/GetProjectLangTagsResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.lang;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.protege.webprotege.common.LangTag;
@@ -14,6 +15,7 @@ import javax.annotation.Nonnull;
  * 2020-04-26
  */
 @JsonTypeName("webprotege.projects.GetProjectLangTags")
-public record GetProjectLangTagsResult(@Nonnull ProjectId projectId, @Nonnull ImmutableSet<LangTag> langTags) implements Result {
+public record GetProjectLangTagsResult(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                       @JsonProperty("langTags") @Nonnull ImmutableSet<LangTag> langTags) implements Result {
 
 }

--- a/src/main/java/edu/stanford/protege/webprotege/mail/GetEmailAddressAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/mail/GetEmailAddressAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.mail;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.UserId;
 import edu.stanford.protege.webprotege.dispatch.Action;
@@ -11,7 +12,7 @@ import edu.stanford.protege.webprotege.dispatch.Action;
  * Date: 06/11/2013
  */
 @JsonTypeName("webprotege.users.GetEmailAddress")
-public record GetEmailAddressAction(UserId userId) implements Action<GetEmailAddressResult> {
+public record GetEmailAddressAction(@JsonProperty("userId") UserId userId) implements Action<GetEmailAddressResult> {
 
     public static final String CHANNEL = "webprotege.users.GetEmailAddress";
 

--- a/src/main/java/edu/stanford/protege/webprotege/mail/SetEmailAddressAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/mail/SetEmailAddressAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.mail;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.UserId;
 import edu.stanford.protege.webprotege.dispatch.Action;
@@ -19,7 +20,8 @@ import edu.stanford.protege.webprotege.user.EmailAddress;
  *
  */
 @JsonTypeName("webprotege.users.SetEmailAddress")
-public record SetEmailAddressAction(UserId userId, EmailAddress emailAddress) implements Action<SetEmailAddressResult> {
+public record SetEmailAddressAction(@JsonProperty("userId") UserId userId,
+                                    @JsonProperty("emailAddress") EmailAddress emailAddress) implements Action<SetEmailAddressResult> {
 
     public static final String CHANNEL = "webprotege.users.SetEmailAddress";
 

--- a/src/main/java/edu/stanford/protege/webprotege/mail/SetEmailAddressResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/mail/SetEmailAddressResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.mail;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.dispatch.Result;
 
@@ -10,7 +11,7 @@ import edu.stanford.protege.webprotege.dispatch.Result;
  * Date: 06/11/2013
  */
 @JsonTypeName("webprotege.users.SetEmailAddress")
-public record SetEmailAddressResult(Result result) implements Result {
+public record SetEmailAddressResult(@JsonProperty("result") Result result) implements Result {
 
     public enum Result {
         /**

--- a/src/main/java/edu/stanford/protege/webprotege/match/GetMatchingEntitiesResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/match/GetMatchingEntitiesResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.match;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.Page;
 import edu.stanford.protege.webprotege.common.Response;
@@ -16,6 +17,6 @@ import javax.annotation.Nonnull;
 
 
 @JsonTypeName("webprotege.entities.GetMatchingEntities")
-public record GetMatchingEntitiesResult(@Nonnull Page<EntityNode> entities) implements Result, Response {
+public record GetMatchingEntitiesResult(@JsonProperty("entities") @Nonnull Page<EntityNode> entities) implements Result, Response {
 
 }

--- a/src/main/java/edu/stanford/protege/webprotege/merge/ComputeProjectMergeResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/merge/ComputeProjectMergeResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.merge;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.diff.DiffElement;
 import edu.stanford.protege.webprotege.dispatch.Result;
@@ -14,6 +15,6 @@ import java.util.List;
 
 
 @JsonTypeName("webprotege.projects.ComputeProjectMerge")
-public record ComputeProjectMergeResult(List<DiffElement<String, String>> diff) implements Result {
+public record ComputeProjectMergeResult(@JsonProperty("diff") List<DiffElement<String, String>> diff) implements Result {
 
 }

--- a/src/main/java/edu/stanford/protege/webprotege/ontology/GetRootOntologyIdAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/ontology/GetRootOntologyIdAction.java
@@ -1,6 +1,7 @@
 package edu.stanford.protege.webprotege.ontology;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.ProjectAction;
@@ -14,7 +15,7 @@ import edu.stanford.protege.webprotege.dispatch.ProjectAction;
 
 
 @JsonTypeName("webprotege.ontologies.GetRootOntologyId")
-public record GetRootOntologyIdAction(ProjectId projectId) implements ProjectAction<GetRootOntologyIdResult> {
+public record GetRootOntologyIdAction(@JsonProperty("projectId") ProjectId projectId) implements ProjectAction<GetRootOntologyIdResult> {
 
     public static final String CHANNEL = "webprotege.ontologies.GetRootOntologyId";
 

--- a/src/main/java/edu/stanford/protege/webprotege/permissions/GetProjectPermissionsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/permissions/GetProjectPermissionsAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.permissions;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.common.UserId;
@@ -15,7 +16,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 23/02/15
  */
 @JsonTypeName("webprotege.auth.GetProjectPermissions")
-public record GetProjectPermissionsAction(@Nonnull ProjectId projectId, @Nonnull UserId userId) implements Action<GetProjectPermissionsResult> {
+public record GetProjectPermissionsAction(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                          @JsonProperty("userId") @Nonnull UserId userId) implements Action<GetProjectPermissionsResult> {
 
     public static final String CHANNEL = "webprotege.auth.GetProjectPermissions";
 
@@ -24,7 +26,8 @@ public record GetProjectPermissionsAction(@Nonnull ProjectId projectId, @Nonnull
         return CHANNEL;
     }
 
-    public GetProjectPermissionsAction(@Nonnull ProjectId projectId, @Nonnull UserId userId) {
+    public GetProjectPermissionsAction(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                       @JsonProperty("userId") @Nonnull UserId userId) {
         this.projectId = checkNotNull(projectId);
         this.userId = checkNotNull(userId);
     }

--- a/src/main/java/edu/stanford/protege/webprotege/permissions/GetProjectPermissionsResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/permissions/GetProjectPermissionsResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.permissions;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.protege.webprotege.authorization.Capability;
@@ -11,6 +12,6 @@ import edu.stanford.protege.webprotege.dispatch.Result;
  * 23/02/15
  */
 @JsonTypeName("webprotege.auth.GetProjectPermissions")
-public record GetProjectPermissionsResult(ImmutableSet<Capability> allowedActions) implements Result {
+public record GetProjectPermissionsResult(@JsonProperty("allowedActions") ImmutableSet<Capability> allowedActions) implements Result {
 
 }

--- a/src/main/java/edu/stanford/protege/webprotege/perspective/GetPerspectiveLayoutAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/perspective/GetPerspectiveLayoutAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.perspective;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.common.UserId;
@@ -14,7 +15,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 17/02/16
  */
 @JsonTypeName("webprotege.perspectives.GetPerspectiveLayout")
-public record GetPerspectiveLayoutAction(ProjectId projectId, UserId userId, PerspectiveId perspectiveId) implements ProjectAction<GetPerspectiveLayoutResult>, HasProjectId {
+public record GetPerspectiveLayoutAction(@JsonProperty("projectId") ProjectId projectId,
+                                         @JsonProperty("userId") UserId userId,
+                                         @JsonProperty("perspectiveId") PerspectiveId perspectiveId) implements ProjectAction<GetPerspectiveLayoutResult>, HasProjectId {
 
     public static final String CHANNEL = "webprotege.perspectives.GetPerspectiveLayout";
 
@@ -23,7 +26,9 @@ public record GetPerspectiveLayoutAction(ProjectId projectId, UserId userId, Per
         return CHANNEL;
     }
 
-    public GetPerspectiveLayoutAction(ProjectId projectId, UserId userId, PerspectiveId perspectiveId) {
+    public GetPerspectiveLayoutAction(@JsonProperty("projectId") ProjectId projectId,
+                                      @JsonProperty("userId") UserId userId,
+                                      @JsonProperty("perspectiveId") PerspectiveId perspectiveId) {
         this.projectId = checkNotNull(projectId);
         this.userId = checkNotNull(userId);
         this.perspectiveId = checkNotNull(perspectiveId);

--- a/src/main/java/edu/stanford/protege/webprotege/perspective/GetPerspectiveLayoutResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/perspective/GetPerspectiveLayoutResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.perspective;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.dispatch.Result;
 
@@ -11,6 +12,6 @@ import edu.stanford.protege.webprotege.dispatch.Result;
 
 
 @JsonTypeName("webprotege.perspectives.GetPerspectiveLayout")
-public record GetPerspectiveLayoutResult(PerspectiveLayout layout) implements Result {
+public record GetPerspectiveLayoutResult(@JsonProperty("layout") PerspectiveLayout layout) implements Result {
 
 }

--- a/src/main/java/edu/stanford/protege/webprotege/perspective/ResetPerspectiveLayoutAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/perspective/ResetPerspectiveLayoutAction.java
@@ -1,6 +1,7 @@
 package edu.stanford.protege.webprotege.perspective;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ChangeRequest;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
@@ -21,9 +22,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @param perspectiveId The perspective id.
  */
 @JsonTypeName("webprotege.perspectives.ResetPerspectiveLayout")
-public record ResetPerspectiveLayoutAction(ChangeRequestId changeRequestId,
-                                           ProjectId projectId,
-                                           PerspectiveId perspectiveId) implements ProjectAction<ResetPerspectiveLayoutResult>, ChangeRequest {
+public record ResetPerspectiveLayoutAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                           @JsonProperty("projectId") ProjectId projectId,
+                                           @JsonProperty("perspectiveId") PerspectiveId perspectiveId) implements ProjectAction<ResetPerspectiveLayoutResult>, ChangeRequest {
 
     public static final String CHANNEL = "webprotege.perspectives.ResetPerspectiveLayout";
 
@@ -32,7 +33,9 @@ public record ResetPerspectiveLayoutAction(ChangeRequestId changeRequestId,
         return CHANNEL;
     }
 
-    public ResetPerspectiveLayoutAction(ChangeRequestId changeRequestId, ProjectId projectId, PerspectiveId perspectiveId) {
+    public ResetPerspectiveLayoutAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                        @JsonProperty("projectId") ProjectId projectId,
+                                        @JsonProperty("perspectiveId") PerspectiveId perspectiveId) {
         this.changeRequestId = checkNotNull(changeRequestId);
         this.projectId = checkNotNull(projectId);
         this.perspectiveId = checkNotNull(perspectiveId);

--- a/src/main/java/edu/stanford/protege/webprotege/perspective/ResetPerspectiveLayoutResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/perspective/ResetPerspectiveLayoutResult.java
@@ -1,6 +1,7 @@
 package edu.stanford.protege.webprotege.perspective;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.dispatch.Result;
 
@@ -14,9 +15,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 15 Mar 2017
  */
 @JsonTypeName("webprotege.perspectives.ResetPerspectiveLayout")
-public record ResetPerspectiveLayoutResult(@Nonnull PerspectiveLayout resetLayout) implements Result {
+public record ResetPerspectiveLayoutResult(@JsonProperty("resetLayout") @Nonnull PerspectiveLayout resetLayout) implements Result {
 
-    public ResetPerspectiveLayoutResult(@Nonnull PerspectiveLayout resetLayout) {
+    public ResetPerspectiveLayoutResult(@JsonProperty("resetLayout") @Nonnull PerspectiveLayout resetLayout) {
         this.resetLayout = checkNotNull(resetLayout);
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotege/perspective/SetPerspectiveLayoutAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/perspective/SetPerspectiveLayoutAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.perspective;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ChangeRequest;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
@@ -16,10 +17,10 @@ import java.util.Objects;
  * 28/02/16
  */
 @JsonTypeName("webprotege.perspectives.SetPerspectiveLayout")
-public record SetPerspectiveLayoutAction(@Nonnull ChangeRequestId changeRequestId,
-                                         @Nonnull ProjectId projectId,
-                                         @Nonnull UserId userId,
-                                         @Nonnull PerspectiveLayout layout) implements ProjectAction<SetPerspectiveLayoutResult>, ChangeRequest {
+public record SetPerspectiveLayoutAction(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                         @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                         @JsonProperty("userId") @Nonnull UserId userId,
+                                         @JsonProperty("layout") @Nonnull PerspectiveLayout layout) implements ProjectAction<SetPerspectiveLayoutResult>, ChangeRequest {
 
     public static final String CHANNEL = "webprotege.perspectives.SetPerspectiveLayout";
 
@@ -28,10 +29,10 @@ public record SetPerspectiveLayoutAction(@Nonnull ChangeRequestId changeRequestI
         return CHANNEL;
     }
 
-    public SetPerspectiveLayoutAction(@Nonnull ChangeRequestId changeRequestId,
-                                      @Nonnull ProjectId projectId,
-                                      @Nonnull UserId userId,
-                                      @Nonnull PerspectiveLayout layout) {
+    public SetPerspectiveLayoutAction(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                      @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                      @JsonProperty("userId") @Nonnull UserId userId,
+                                      @JsonProperty("layout") @Nonnull PerspectiveLayout layout) {
         this.changeRequestId = Objects.requireNonNull(changeRequestId);
         this.projectId = Objects.requireNonNull(projectId);
         this.userId = Objects.requireNonNull(userId);

--- a/src/main/java/edu/stanford/protege/webprotege/project/CreateNewProjectResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/project/CreateNewProjectResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.project;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.Response;
 import edu.stanford.protege.webprotege.dispatch.Result;
@@ -12,9 +13,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 21/02/15
  */
 @JsonTypeName("webprotege.projects.CreateNewProject")
-public record CreateNewProjectResult(ProjectDetails projectDetails) implements Result, Response {
+public record CreateNewProjectResult(@JsonProperty("projectDetails") ProjectDetails projectDetails) implements Result, Response {
 
-    public CreateNewProjectResult(ProjectDetails projectDetails) {
+    public CreateNewProjectResult(@JsonProperty("projectDetails") ProjectDetails projectDetails) {
         this.projectDetails = checkNotNull(projectDetails);
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotege/project/GetProjectDetailsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/project/GetProjectDetailsAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.project;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.Action;
@@ -12,7 +13,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 10/03/16
  */
 @JsonTypeName("webprotege.projects.GetProjectDetails")
-public record GetProjectDetailsAction(ProjectId projectId) implements Action<GetProjectDetailsResult>, HasProjectId {
+public record GetProjectDetailsAction(@JsonProperty("projectId") ProjectId projectId) implements Action<GetProjectDetailsResult>, HasProjectId {
 
     public static final String CHANNEL = "webprotege.projects.GetProjectDetails";
 
@@ -21,7 +22,7 @@ public record GetProjectDetailsAction(ProjectId projectId) implements Action<Get
         return CHANNEL;
     }
 
-    public GetProjectDetailsAction(ProjectId projectId) {
+    public GetProjectDetailsAction(@JsonProperty("projectId") ProjectId projectId) {
         this.projectId = checkNotNull(projectId);
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotege/project/GetProjectDetailsResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/project/GetProjectDetailsResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.project;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.dispatch.Result;
 
@@ -13,9 +14,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 
 @JsonTypeName("webprotege.projects.GetProjectDetails")
-public record GetProjectDetailsResult(ProjectDetails projectDetails) implements Result {
+public record GetProjectDetailsResult(@JsonProperty("projectDetails") ProjectDetails projectDetails) implements Result {
 
-    public GetProjectDetailsResult(ProjectDetails projectDetails) {
+    public GetProjectDetailsResult(@JsonProperty("projectDetails") ProjectDetails projectDetails) {
         this.projectDetails = checkNotNull(projectDetails);
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotege/project/GetProjectInfoAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/project/GetProjectInfoAction.java
@@ -1,6 +1,7 @@
 package edu.stanford.protege.webprotege.project;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.ProjectAction;
@@ -11,7 +12,7 @@ import edu.stanford.protege.webprotege.dispatch.ProjectAction;
  * 21 Aug 2018
  */
 @JsonTypeName("webprotege.projects.GetProjectInfo")
-public record GetProjectInfoAction(ProjectId projectId) implements ProjectAction<GetProjectInfoResult> {
+public record GetProjectInfoAction(@JsonProperty("projectId") ProjectId projectId) implements ProjectAction<GetProjectInfoResult> {
 
     public static final String CHANNEL = "webprotege.projects.GetProjectInfo";
 

--- a/src/main/java/edu/stanford/protege/webprotege/project/LoadProjectAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/project/LoadProjectAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.project;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.Action;
@@ -13,7 +14,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Date: 05/04/2013
  */
 @JsonTypeName("webprotege.projects.LoadProject")
-public record LoadProjectAction(ProjectId projectId) implements Action<LoadProjectResult>, HasProjectId {
+public record LoadProjectAction(@JsonProperty("projectId") ProjectId projectId) implements Action<LoadProjectResult>, HasProjectId {
 
     public static final String CHANNEL = "webprotege.projects.LoadProject";
 
@@ -22,7 +23,7 @@ public record LoadProjectAction(ProjectId projectId) implements Action<LoadProje
         return CHANNEL;
     }
 
-    public LoadProjectAction(ProjectId projectId) {
+    public LoadProjectAction(@JsonProperty("projectId") ProjectId projectId) {
         this.projectId = checkNotNull(projectId);
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotege/project/MoveProjectsToTrashAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/project/MoveProjectsToTrashAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.project;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.Action;
@@ -13,7 +14,7 @@ import edu.stanford.protege.webprotege.dispatch.Action;
 
 
 @JsonTypeName("webprotege.projects.MoveProjectToTrash")
-public record MoveProjectsToTrashAction(ProjectId projectId) implements Action<MoveProjectsToTrashResult> {
+public record MoveProjectsToTrashAction(@JsonProperty("projectId") ProjectId projectId) implements Action<MoveProjectsToTrashResult> {
 
     public static final String CHANNEL = "webprotege.projects.MoveProjectToTrash";
 

--- a/src/main/java/edu/stanford/protege/webprotege/project/RemoveProjectFromTrashAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/project/RemoveProjectFromTrashAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.project;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.Action;
@@ -13,7 +14,7 @@ import edu.stanford.protege.webprotege.dispatch.Action;
 
 
 @JsonTypeName("webprotege.projects.RemoveProjectFromTrash")
-public record RemoveProjectFromTrashAction(ProjectId projectId) implements Action<RemoveProjectFromTrashResult> {
+public record RemoveProjectFromTrashAction(@JsonProperty("projectId") ProjectId projectId) implements Action<RemoveProjectFromTrashResult> {
 
     public static final String CHANNEL = "webprotege.projects.RemoveProjectFromTrash";
 

--- a/src/main/java/edu/stanford/protege/webprotege/project/SetProjectPrefixDeclarationsResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/project/SetProjectPrefixDeclarationsResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.project;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.Result;
@@ -15,11 +16,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 1 Mar 2018
  */
 @JsonTypeName("webprotege.projects.SetProjectPrefixDeclarations")
-public record SetProjectPrefixDeclarationsResult(@Nonnull ProjectId projectId,
-                                                @Nonnull List<PrefixDeclaration> prefixDeclarations) implements Result {
+public record SetProjectPrefixDeclarationsResult(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                                @JsonProperty("prefixDeclarations") @Nonnull List<PrefixDeclaration> prefixDeclarations) implements Result {
 
-    public SetProjectPrefixDeclarationsResult(@Nonnull ProjectId projectId,
-                                              @Nonnull List<PrefixDeclaration> prefixDeclarations) {
+    public SetProjectPrefixDeclarationsResult(@JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                              @JsonProperty("prefixDeclarations") @Nonnull List<PrefixDeclaration> prefixDeclarations) {
         this.projectId = checkNotNull(projectId);
         this.prefixDeclarations = checkNotNull(prefixDeclarations);
     }

--- a/src/main/java/edu/stanford/protege/webprotege/projectsettings/GetProjectSettingsResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/projectsettings/GetProjectSettingsResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.projectsettings;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.dispatch.Result;
 
@@ -11,9 +12,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 25/11/14
  */
 @JsonTypeName("webprotege.projects.GetProjectSettings")
-public record GetProjectSettingsResult(ProjectSettings settings) implements Result {
+public record GetProjectSettingsResult(@JsonProperty("settings") ProjectSettings settings) implements Result {
 
-    public GetProjectSettingsResult(ProjectSettings settings) {
+    public GetProjectSettingsResult(@JsonProperty("settings") ProjectSettings settings) {
         this.settings = checkNotNull(settings);
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotege/renderer/GetEntityRenderingResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/renderer/GetEntityRenderingResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.renderer;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.dispatch.Result;
 import edu.stanford.protege.webprotege.entity.OWLEntityData;
@@ -12,6 +13,6 @@ import javax.annotation.Nonnull;
 
 
 @JsonTypeName("webprotege.entities.GetEntityRendering")
-public record GetEntityRenderingResult(@Nonnull OWLEntityData entityData) implements Result {
+public record GetEntityRenderingResult(@JsonProperty("entityData") @Nonnull OWLEntityData entityData) implements Result {
 
 }

--- a/src/main/java/edu/stanford/protege/webprotege/revision/GetHeadRevisionNumberAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/revision/GetHeadRevisionNumberAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.revision;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.ProjectAction;
@@ -12,7 +13,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 21/02/15
  */
 @JsonTypeName("webprotege.history.GetHeadRevisionNumber")
-public record GetHeadRevisionNumberAction(ProjectId projectId) implements ProjectAction<GetHeadRevisionNumberResult> {
+public record GetHeadRevisionNumberAction(@JsonProperty("projectId") ProjectId projectId) implements ProjectAction<GetHeadRevisionNumberResult> {
 
     public static final String CHANNEL = "webprotege.history.GetHeadRevisionNumber";
 
@@ -21,7 +22,7 @@ public record GetHeadRevisionNumberAction(ProjectId projectId) implements Projec
         return CHANNEL;
     }
 
-    public GetHeadRevisionNumberAction(ProjectId projectId) {
+    public GetHeadRevisionNumberAction(@JsonProperty("projectId") ProjectId projectId) {
         this.projectId = checkNotNull(projectId);
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotege/revision/GetRevisionSummariesResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/revision/GetRevisionSummariesResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.revision;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.Page;
 import edu.stanford.protege.webprotege.dispatch.Result;
@@ -12,9 +13,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 21/02/15
  */
 @JsonTypeName("webprotege.history.GetRevisionSummaries")
-public record GetRevisionSummariesResult(Page<RevisionSummary> revisionSummaries) implements Result {
+public record GetRevisionSummariesResult(@JsonProperty("revisionSummaries") Page<RevisionSummary> revisionSummaries) implements Result {
 
-    public GetRevisionSummariesResult(Page<RevisionSummary> revisionSummaries) {
+    public GetRevisionSummariesResult(@JsonProperty("revisionSummaries") Page<RevisionSummary> revisionSummaries) {
         this.revisionSummaries = checkNotNull(revisionSummaries);
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotege/search/GetSearchSettingsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/search/GetSearchSettingsAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.search;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.ProjectAction;
@@ -12,7 +13,7 @@ import edu.stanford.protege.webprotege.dispatch.ProjectAction;
 
 
 @JsonTypeName("webprotege.search.GetSearchSettings")
-public record GetSearchSettingsAction(ProjectId projectId) implements ProjectAction<GetSearchSettingsResult> {
+public record GetSearchSettingsAction(@JsonProperty("projectId") ProjectId projectId) implements ProjectAction<GetSearchSettingsResult> {
 
     public static final String CHANNEL = "webprotege.search.GetSearchSettings";
 

--- a/src/main/java/edu/stanford/protege/webprotege/sharing/GetProjectSharingSettingsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/sharing/GetProjectSharingSettingsAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.sharing;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.ProjectAction;
@@ -12,7 +13,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 07/02/15
  */
 @JsonTypeName("webprotege.projects.GetProjectSharingSettings")
-public record GetProjectSharingSettingsAction(ProjectId projectId) implements ProjectAction<GetProjectSharingSettingsResult> {
+public record GetProjectSharingSettingsAction(@JsonProperty("projectId") ProjectId projectId) implements ProjectAction<GetProjectSharingSettingsResult> {
 
     public static final String CHANNEL = "webprotege.projects.GetProjectSharingSettings";
 
@@ -21,7 +22,7 @@ public record GetProjectSharingSettingsAction(ProjectId projectId) implements Pr
         return CHANNEL;
     }
 
-    public GetProjectSharingSettingsAction(ProjectId projectId) {
+    public GetProjectSharingSettingsAction(@JsonProperty("projectId") ProjectId projectId) {
         this.projectId = checkNotNull(projectId);
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotege/sharing/SetProjectSharingSettingsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/sharing/SetProjectSharingSettingsAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.sharing;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ChangeRequest;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
@@ -14,8 +15,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 07/02/15
  */
 @JsonTypeName("webprotege.sharing.SetProjectSharingSettings")
-public record SetProjectSharingSettingsAction(ChangeRequestId changeRequestId,
-                                              ProjectId projectId, ProjectSharingSettings settings) implements ProjectAction<SetProjectSharingSettingsResult>, ChangeRequest {
+public record SetProjectSharingSettingsAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                              @JsonProperty("projectId") ProjectId projectId,
+                                              @JsonProperty("settings") ProjectSharingSettings settings) implements ProjectAction<SetProjectSharingSettingsResult>, ChangeRequest {
 
     public static final String CHANNEL = "webprotege.sharing.SetProjectSharingSettings";
 
@@ -24,7 +26,9 @@ public record SetProjectSharingSettingsAction(ChangeRequestId changeRequestId,
         return CHANNEL;
     }
 
-    public SetProjectSharingSettingsAction(ChangeRequestId changeRequestId, ProjectId projectId, ProjectSharingSettings settings) {
+    public SetProjectSharingSettingsAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                           @JsonProperty("projectId") ProjectId projectId,
+                                           @JsonProperty("settings") ProjectSharingSettings settings) {
         this.changeRequestId = checkNotNull(changeRequestId);
         this.projectId = checkNotNull(projectId);
         this.settings = checkNotNull(settings);

--- a/src/main/java/edu/stanford/protege/webprotege/tag/AddProjectTagResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/tag/AddProjectTagResult.java
@@ -15,7 +15,7 @@ import java.util.Optional;
  * 18 Mar 2018
  */
 @JsonTypeName("webprotege.tags.AddProjectTag")
-public record AddProjectTagResult(Tag addedTag) implements Result {
+public record AddProjectTagResult(@JsonProperty("addedTag") Tag addedTag) implements Result {
 
     @JsonCreator
     public static AddProjectTagResult create(@JsonProperty("addedTag") @Nullable Tag addedTag) {

--- a/src/main/java/edu/stanford/protege/webprotege/tag/GetEntityTagsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/tag/GetEntityTagsAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.tag;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.ProjectAction;
@@ -13,7 +14,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 18 Mar 2018
  */
 @JsonTypeName("webprotege.tags.GetEntityTags")
-public record GetEntityTagsAction(ProjectId projectId, OWLEntity entity) implements ProjectAction<GetEntityTagsResult> {
+public record GetEntityTagsAction(@JsonProperty("projectId") ProjectId projectId,
+                                  @JsonProperty("entity") OWLEntity entity) implements ProjectAction<GetEntityTagsResult> {
 
     public static final String CHANNEL = "webprotege.tags.GetEntityTags";
 
@@ -22,7 +24,8 @@ public record GetEntityTagsAction(ProjectId projectId, OWLEntity entity) impleme
         return CHANNEL;
     }
 
-    public GetEntityTagsAction(ProjectId projectId, OWLEntity entity) {
+    public GetEntityTagsAction(@JsonProperty("projectId") ProjectId projectId,
+                               @JsonProperty("entity") OWLEntity entity) {
         this.projectId = checkNotNull(projectId);
         this.entity = checkNotNull(entity);
     }

--- a/src/main/java/edu/stanford/protege/webprotege/tag/GetEntityTagsResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/tag/GetEntityTagsResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.tag;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.dispatch.Result;
 
@@ -13,10 +14,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 18 Mar 2018
  */
 @JsonTypeName("webprotege.tags.GetEntityTags")
-public record GetEntityTagsResult(Collection<Tag> entityTags,
-                                 Collection<Tag> projectTags) implements Result {
+public record GetEntityTagsResult(@JsonProperty("entityTags") Collection<Tag> entityTags,
+                                 @JsonProperty("projectTags") Collection<Tag> projectTags) implements Result {
 
-    public GetEntityTagsResult(Collection<Tag> entityTags, Collection<Tag> projectTags) {
+    public GetEntityTagsResult(@JsonProperty("entityTags") Collection<Tag> entityTags,
+                               @JsonProperty("projectTags") Collection<Tag> projectTags) {
         this.entityTags = checkNotNull(entityTags);
         this.projectTags = checkNotNull(projectTags);
     }

--- a/src/main/java/edu/stanford/protege/webprotege/tag/GetProjectTagsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/tag/GetProjectTagsAction.java
@@ -1,6 +1,7 @@
 package edu.stanford.protege.webprotege.tag;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.ProjectAction;
@@ -13,7 +14,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 18 Mar 2018
  */
 @JsonTypeName("webprotege.tags.GetProjectTags")
-public record GetProjectTagsAction(ProjectId projectId) implements ProjectAction<GetProjectTagsResult> {
+public record GetProjectTagsAction(@JsonProperty("projectId") ProjectId projectId) implements ProjectAction<GetProjectTagsResult> {
 
     public static final String CHANNEL = "webprotege.tags.GetProjectTags";
 
@@ -22,7 +23,7 @@ public record GetProjectTagsAction(ProjectId projectId) implements ProjectAction
         return CHANNEL;
     }
 
-    public GetProjectTagsAction(ProjectId projectId) {
+    public GetProjectTagsAction(@JsonProperty("projectId") ProjectId projectId) {
         this.projectId = checkNotNull(projectId);
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotege/tag/GetProjectTagsResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/tag/GetProjectTagsResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.tag;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.dispatch.Result;
 
@@ -14,10 +15,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 18 Mar 2018
  */
 @JsonTypeName("webprotege.tags.GetProjectTags")
-public record GetProjectTagsResult(Set<Tag> tags,
-                                   Map<TagId, Integer> tagUsage) implements Result {
+public record GetProjectTagsResult(@JsonProperty("tags") Set<Tag> tags,
+                                   @JsonProperty("tagUsage") Map<TagId, Integer> tagUsage) implements Result {
 
-    public GetProjectTagsResult(Set<Tag> tags, Map<TagId, Integer> tagUsage) {
+    public GetProjectTagsResult(@JsonProperty("tags") Set<Tag> tags,
+                                @JsonProperty("tagUsage") Map<TagId, Integer> tagUsage) {
         this.tags = checkNotNull(tags);
         this.tagUsage = checkNotNull(tagUsage);
     }

--- a/src/main/java/edu/stanford/protege/webprotege/viz/GetProjectEntityGraphDefaultEdgeCriteriaAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/viz/GetProjectEntityGraphDefaultEdgeCriteriaAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.viz;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.ProjectAction;
@@ -14,7 +15,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 2019-12-07
  */
 @JsonTypeName("webprotege.graphs.GetProjectEntityGraphDefaultEdgeCriteria")
-public record GetProjectEntityGraphDefaultEdgeCriteriaAction(ProjectId projectId) implements ProjectAction<GetProjectEntityGraphDefaultEdgeCriteriaResult> {
+public record GetProjectEntityGraphDefaultEdgeCriteriaAction(@JsonProperty("projectId") ProjectId projectId) implements ProjectAction<GetProjectEntityGraphDefaultEdgeCriteriaResult> {
 
     public static final String CHANNEL = "webprotege.graphs.GetProjectEntityGraphDefaultEdgeCriteria";
 


### PR DESCRIPTION
## Summary
- Adds an explicit `@JsonProperty("<name>")` to every record component flagged `FRAGILE` by the wire-DTO conformance audit (issue #52), so the JSON contract no longer depends on incidental agreement between Java component names and the gwt-ui client.
- Covers all 58 backend files in the issue list; two (`GetDeprecatedEntitiesAction`, `PerformEntitySearchAction`) already had the annotation, so 56 files actually change here.
- Where the file has an explicit canonical constructor, the annotations are mirrored on its parameters too — matching the existing pattern in `GetDeprecatedEntitiesAction` / `PerformEntitySearchAction`.

A renaming of either the Java component or the matching gwt-ui field will now break the wire contract loudly instead of silently deserializing as `null`.

## Test plan
- [x] `mvn -q -DskipTests compile` passes.
- [x] Companion client-side PR in `webprotege-gwt-ui` lands together (26 files; covered separately).
- [x] After both PRs merge, re-run `tools/audit_json_conformance.py` and confirm `FRAGILE=0` and no `MATCH` row regresses to `NAME_MISMATCH`.