### PR TITLE
Reconcile MISMATCH wire DTOs (issue #53) — backend half

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/app/SetApplicationSettingsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/app/SetApplicationSettingsAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.app;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ChangeRequest;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
@@ -15,8 +16,8 @@ import javax.annotation.Nonnull;
 
 
 @JsonTypeName("webprotege.application.SetApplicationSettings")
-public record SetApplicationSettingsAction(ChangeRequestId changeRequestId,
-                                           @Nonnull ApplicationSettings applicationSettings) implements Action<SetApplicationSettingsResult>, ChangeRequest {
+public record SetApplicationSettingsAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                           @JsonProperty("applicationSettings") @Nonnull ApplicationSettings applicationSettings) implements Action<SetApplicationSettingsResult>, ChangeRequest {
 
     public static final String CHANNEL = "webprotege.application.SetApplicationSettings";
 

--- a/src/main/java/edu/stanford/protege/webprotege/bulkop/EditAnnotationsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/bulkop/EditAnnotationsAction.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 
 
 @JsonTypeName("webprotege.bulkop.EditAnnotations")
-public record EditAnnotationsAction(@JsonProperty("contentChangeRequest") ChangeRequestId changeRequestId,
+public record EditAnnotationsAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
                                     @JsonProperty("projectId") @Nonnull ProjectId projectId,
                                     @JsonProperty("entities") @Nonnull ImmutableSet<OWLEntity> entities,
                                     @JsonProperty("operation") Operation operation,

--- a/src/main/java/edu/stanford/protege/webprotege/bulkop/SetAnnotationValueAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/bulkop/SetAnnotationValueAction.java
@@ -21,7 +21,7 @@ import javax.annotation.Nonnull;
 
 
 @JsonTypeName("webprotege.bulkop.SetAnnotationValue")
-public record SetAnnotationValueAction(ChangeRequestId changeRequestId,
+public record SetAnnotationValueAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
                                        @JsonProperty("projectId") @Nonnull ProjectId projectId,
                                        @JsonProperty("entities") @Nonnull ImmutableSet<OWLEntity> entities,
                                        @JsonProperty("property") @Nonnull OWLAnnotationProperty property,

--- a/src/main/java/edu/stanford/protege/webprotege/change/RevertRevisionAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/change/RevertRevisionAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.change;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
 import edu.stanford.protege.webprotege.common.ContentChangeRequest;
@@ -13,7 +14,9 @@ import edu.stanford.protege.webprotege.revision.RevisionNumber;
  * 19/03/15
  */
 @JsonTypeName("webprotege.history.RevertRevision")
-public record RevertRevisionAction(ChangeRequestId changeRequestId, ProjectId projectId, RevisionNumber revisionNumber) implements ProjectAction<RevertRevisionResult>, ContentChangeRequest {
+public record RevertRevisionAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                   @JsonProperty("projectId") ProjectId projectId,
+                                   @JsonProperty("revisionNumber") RevisionNumber revisionNumber) implements ProjectAction<RevertRevisionResult>, ContentChangeRequest {
 
     public static final String CHANNEL = "webprotege.history.RevertRevision";
 

--- a/src/main/java/edu/stanford/protege/webprotege/crud/SetEntityCrudKitSettingsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/crud/SetEntityCrudKitSettingsAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.crud;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ChangeRequest;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
@@ -13,8 +14,11 @@ import edu.stanford.protege.webprotege.dispatch.ProjectAction;
  * Date: 8/19/13
  */
 @JsonTypeName("webprotege.projects.SetEntityCrudKitSettings")
-public record SetEntityCrudKitSettingsAction(ChangeRequestId changeRequestId,
-                                             ProjectId projectId, EntityCrudKitSettings fromSettings, EntityCrudKitSettings toSettings, IRIPrefixUpdateStrategy prefixUpdateStrategy) implements ProjectAction<SetEntityCrudKitSettingsResult>, ChangeRequest {
+public record SetEntityCrudKitSettingsAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                             @JsonProperty("projectId") ProjectId projectId,
+                                             @JsonProperty("fromSettings") EntityCrudKitSettings fromSettings,
+                                             @JsonProperty("toSettings") EntityCrudKitSettings toSettings,
+                                             @JsonProperty("prefixUpdateStrategy") IRIPrefixUpdateStrategy prefixUpdateStrategy) implements ProjectAction<SetEntityCrudKitSettingsResult>, ChangeRequest {
 
     public static final String CHANNEL = "webprotege.projects.SetEntityCrudKitSettings";
 

--- a/src/main/java/edu/stanford/protege/webprotege/entity/MergeEntitiesAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/entity/MergeEntitiesAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableSet;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
@@ -26,12 +27,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @param treatment The treatment for the merged term that specifies whether the merged term
  */
 @JsonTypeName("webprotege.entities.MergeEntities")
-public record MergeEntitiesAction(@Nonnull ChangeRequestId changeRequestId,
-                                  @Nonnull ProjectId projectId,
-                                  @Nonnull ImmutableSet<OWLEntity> sourceEntities,
-                                  @Nonnull OWLEntity targetEntity,
-                                  @Nonnull MergedEntityTreatment treatment,
-                                  @Nonnull String commitMessage) implements ProjectAction<MergeEntitiesResult>, ContentChangeRequest {
+public record MergeEntitiesAction(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                  @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                  @JsonProperty("sourceEntities") @Nonnull ImmutableSet<OWLEntity> sourceEntities,
+                                  @JsonProperty("targetEntity") @Nonnull OWLEntity targetEntity,
+                                  @JsonProperty("treatment") @Nonnull MergedEntityTreatment treatment,
+                                  @JsonProperty("commitMessage") @Nonnull String commitMessage) implements ProjectAction<MergeEntitiesResult>, ContentChangeRequest {
 
     public static final String CHANNEL = "webprotege.entities.MergeEntities";
 

--- a/src/main/java/edu/stanford/protege/webprotege/event/EntityDeprecationStatusChangedEvent.java
+++ b/src/main/java/edu/stanford/protege/webprotege/event/EntityDeprecationStatusChangedEvent.java
@@ -1,6 +1,7 @@
 package edu.stanford.protege.webprotege.event;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.EventId;
 import edu.stanford.protege.webprotege.common.ProjectEvent;
@@ -14,10 +15,10 @@ import org.semanticweb.owlapi.model.OWLEntity;
  * Date: 21/03/2013
  */
 @JsonTypeName("webprotege.events.entities.EntityDeprecationStatusChanged")
-public record EntityDeprecationStatusChangedEvent(EventId eventId,
-                                                  ProjectId projectId,
-                                                  OWLEntity entity,
-                                                  boolean deprecated) implements ProjectEvent {
+public record EntityDeprecationStatusChangedEvent(@JsonProperty("eventId") EventId eventId,
+                                                  @JsonProperty("projectId") ProjectId projectId,
+                                                  @JsonProperty("entity") OWLEntity entity,
+                                                  @JsonProperty("deprecated") boolean deprecated) implements ProjectEvent {
 
     public static final String CHANNEL = "webprotege.events.entities.EntityDeprecationStatusChanged";
 

--- a/src/main/java/edu/stanford/protege/webprotege/event/LargeNumberOfChangesEvent.java
+++ b/src/main/java/edu/stanford/protege/webprotege/event/LargeNumberOfChangesEvent.java
@@ -1,6 +1,7 @@
 package edu.stanford.protege.webprotege.event;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.EventId;
 import edu.stanford.protege.webprotege.common.ProjectEvent;
@@ -12,8 +13,8 @@ import edu.stanford.protege.webprotege.common.ProjectId;
  * 2020-11-04
  */
 @JsonTypeName("webprotege.events.projects.LargeNumberOfChanges")
-public record LargeNumberOfChangesEvent(EventId eventId,
-                                        ProjectId projectId) implements ProjectEvent {
+public record LargeNumberOfChangesEvent(@JsonProperty("eventId") EventId eventId,
+                                        @JsonProperty("projectId") ProjectId projectId) implements ProjectEvent {
 
     public static final String CHANNEL = "webprotege.events.projects.LargeNumberOfChanges";
 

--- a/src/main/java/edu/stanford/protege/webprotege/event/ProjectChangedEvent.java
+++ b/src/main/java/edu/stanford/protege/webprotege/event/ProjectChangedEvent.java
@@ -1,6 +1,7 @@
 package edu.stanford.protege.webprotege.event;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.EventId;
 import edu.stanford.protege.webprotege.common.ProjectEvent;
@@ -23,8 +24,10 @@ import java.util.Set;
  * @throws NullPointerException if any parameters are {@code null}.
  */
 @JsonTypeName("webprotege.events.project.ProjectChanged")
-public record ProjectChangedEvent(EventId eventId,
-                                  ProjectId projectId, RevisionSummary revisionSummary, Set<OWLEntityData> subjects) implements ProjectEvent {
+public record ProjectChangedEvent(@JsonProperty("eventId") EventId eventId,
+                                  @JsonProperty("projectId") ProjectId projectId,
+                                  @JsonProperty("revisionSummary") RevisionSummary revisionSummary,
+                                  @JsonProperty("subjects") Set<OWLEntityData> subjects) implements ProjectEvent {
 
     public static final String CHANNEL = "webprotege.events.project.ProjectChanged";
 

--- a/src/main/java/edu/stanford/protege/webprotege/hierarchy/GetHierarchySiblingsResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/hierarchy/GetHierarchySiblingsResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.hierarchy;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.Page;
 import edu.stanford.protege.webprotege.dispatch.Result;
@@ -13,6 +14,6 @@ import edu.stanford.protege.webprotege.entity.EntityNode;
 
 
 @JsonTypeName("webprotege.hierarchies.GetHierarchySiblings")
-public record GetHierarchySiblingsResult(Page<GraphNode<EntityNode>> siblingsPage) implements Result {
+public record GetHierarchySiblingsResult(@JsonProperty("siblingsPage") Page<GraphNode<EntityNode>> siblingsPage) implements Result {
 
 }

--- a/src/main/java/edu/stanford/protege/webprotege/individuals/GetIndividualsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/individuals/GetIndividualsAction.java
@@ -1,6 +1,7 @@
 package edu.stanford.protege.webprotege.individuals;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.PageRequest;
 import edu.stanford.protege.webprotege.common.ProjectId;
@@ -14,11 +15,11 @@ import org.semanticweb.owlapi.model.OWLClass;
  * Date: 12/09/2013
  */
 @JsonTypeName("webprotege.entities.GetIndividuals")
-public record GetIndividualsAction(ProjectId projectId,
-                                  OWLClass type,
-                                  PageRequest pageRequest,
-                                  String searchString,
-                                  InstanceRetrievalMode instanceRetrievalMode) implements ProjectAction<GetIndividualsResult> {
+public record GetIndividualsAction(@JsonProperty("projectId") ProjectId projectId,
+                                  @JsonProperty("type") OWLClass type,
+                                  @JsonProperty("pageRequest") PageRequest pageRequest,
+                                  @JsonProperty("searchString") String searchString,
+                                  @JsonProperty("instanceRetrievalMode") InstanceRetrievalMode instanceRetrievalMode) implements ProjectAction<GetIndividualsResult> {
 
     public static final String CHANNEL = "webprotege.entities.GetIndividuals";
 

--- a/src/main/java/edu/stanford/protege/webprotege/issues/AddCommentAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/issues/AddCommentAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.issues;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
 import edu.stanford.protege.webprotege.common.ContentChangeRequest;
@@ -13,10 +14,10 @@ import edu.stanford.protege.webprotege.project.HasProjectId;
  * 7 Oct 2016
  */
 @JsonTypeName("webprotege.discussions.AddComment")
-public record AddCommentAction(ChangeRequestId changeRequestId,
-                               ProjectId projectId,
-                               ThreadId threadId,
-                               String comment) implements ProjectAction<AddCommentResult>, HasProjectId, ContentChangeRequest {
+public record AddCommentAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                               @JsonProperty("projectId") ProjectId projectId,
+                               @JsonProperty("threadId") ThreadId threadId,
+                               @JsonProperty("comment") String comment) implements ProjectAction<AddCommentResult>, HasProjectId, ContentChangeRequest {
 
     public static final String CHANNEL = "webprotege.discussions.AddComment";
 

--- a/src/main/java/edu/stanford/protege/webprotege/issues/CommentUpdatedEvent.java
+++ b/src/main/java/edu/stanford/protege/webprotege/issues/CommentUpdatedEvent.java
@@ -1,6 +1,7 @@
 package edu.stanford.protege.webprotege.issues;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.EventId;
 import edu.stanford.protege.webprotege.common.ProjectEvent;
@@ -14,10 +15,10 @@ import javax.annotation.Nonnull;
  * 11 Oct 2016
  */
 @JsonTypeName("webprotege.events.discussions.CommentUpdated")
-public record CommentUpdatedEvent(@Nonnull EventId eventId,
-                                  @Nonnull ProjectId projectId,
-                                  @Nonnull ThreadId threadId,
-                                  @Nonnull Comment comment) implements ProjectEvent {
+public record CommentUpdatedEvent(@JsonProperty("eventId") @Nonnull EventId eventId,
+                                  @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                  @JsonProperty("threadId") @Nonnull ThreadId threadId,
+                                  @JsonProperty("comment") @Nonnull Comment comment) implements ProjectEvent {
 
     public static final String CHANNEL = "webprotege.events.discussions.CommentUpdated";
 

--- a/src/main/java/edu/stanford/protege/webprotege/issues/CreateEntityDiscussionThreadAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/issues/CreateEntityDiscussionThreadAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.issues;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
 import edu.stanford.protege.webprotege.common.ContentChangeRequest;
@@ -13,10 +14,10 @@ import org.semanticweb.owlapi.model.OWLEntity;
  * 6 Oct 2016
  */
 @JsonTypeName("webprotege.discussions.CreateEntityDiscussionThread")
-public record CreateEntityDiscussionThreadAction(ChangeRequestId changeRequestId,
-                                                 ProjectId projectId,
-                                                 OWLEntity entity,
-                                                 String comment) implements ProjectAction<CreateEntityDiscussionThreadResult>, ContentChangeRequest {
+public record CreateEntityDiscussionThreadAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                                 @JsonProperty("projectId") ProjectId projectId,
+                                                 @JsonProperty("entity") OWLEntity entity,
+                                                 @JsonProperty("comment") String comment) implements ProjectAction<CreateEntityDiscussionThreadResult>, ContentChangeRequest {
 
     public static final String CHANNEL = "webprotege.discussions.CreateEntityDiscussionThread";
 

--- a/src/main/java/edu/stanford/protege/webprotege/issues/DeleteCommentAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/issues/DeleteCommentAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.issues;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
 import edu.stanford.protege.webprotege.common.ContentChangeRequest;
@@ -12,9 +13,9 @@ import edu.stanford.protege.webprotege.dispatch.ProjectAction;
  * 9 Oct 2016
  */
 @JsonTypeName("webprotege.discussions.DeleteComment")
-public record DeleteCommentAction(ChangeRequestId changeRequestId,
-                                  ProjectId projectId,
-                                  CommentId commentId) implements ProjectAction<DeleteCommentResult>, ContentChangeRequest {
+public record DeleteCommentAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                  @JsonProperty("projectId") ProjectId projectId,
+                                  @JsonProperty("commentId") CommentId commentId) implements ProjectAction<DeleteCommentResult>, ContentChangeRequest {
 
     public static final String CHANNEL = "webprotege.discussions.DeleteComment";
 

--- a/src/main/java/edu/stanford/protege/webprotege/issues/SetDiscussionThreadStatusAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/issues/SetDiscussionThreadStatusAction.java
@@ -1,6 +1,7 @@
 package edu.stanford.protege.webprotege.issues;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
 import edu.stanford.protege.webprotege.common.ContentChangeRequest;
@@ -15,10 +16,10 @@ import javax.annotation.Nonnull;
  * 12 Oct 2016
  */
 @JsonTypeName("webprotege.discussions.SetDiscussionThreadStatus")
-public record SetDiscussionThreadStatusAction(ChangeRequestId changeRequestId,
-                                              @Nonnull ProjectId projectId,
-                                              @Nonnull ThreadId threadId,
-                                              @Nonnull Status status) implements ProjectAction<SetDiscussionThreadStatusResult>, ContentChangeRequest {
+public record SetDiscussionThreadStatusAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                              @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                              @JsonProperty("threadId") @Nonnull ThreadId threadId,
+                                              @JsonProperty("status") @Nonnull Status status) implements ProjectAction<SetDiscussionThreadStatusResult>, ContentChangeRequest {
 
     public static final String CHANNEL = "webprotege.discussions.SetDiscussionThreadStatus";
 

--- a/src/main/java/edu/stanford/protege/webprotege/lang/DisplayNameSettingsChangedEvent.java
+++ b/src/main/java/edu/stanford/protege/webprotege/lang/DisplayNameSettingsChangedEvent.java
@@ -15,9 +15,9 @@ import javax.annotation.Nonnull;
  * 29 Jul 2018
  */
 @JsonTypeName("webprotege.events.projects.DisplayNameSettingsChanged")
-public record DisplayNameSettingsChangedEvent(EventId eventId,
-                                              ProjectId projectId,
-                                              DisplayNameSettings displayNameSettings) implements ProjectEvent {
+public record DisplayNameSettingsChangedEvent(@JsonProperty("eventId") EventId eventId,
+                                              @JsonProperty("projectId") ProjectId projectId,
+                                              @JsonProperty("displayNameSettings") DisplayNameSettings displayNameSettings) implements ProjectEvent {
 
     public static final String CHANNEL = "webprotege.events.projects.DisplayNameSettingsChanged";
 

--- a/src/main/java/edu/stanford/protege/webprotege/merge/MergeUploadedProjectAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/merge/MergeUploadedProjectAction.java
@@ -16,7 +16,7 @@ import edu.stanford.protege.webprotege.dispatch.ProjectAction;
 
 
 @JsonTypeName("webprotege.projects.MergeUploadedProject")
-public record MergeUploadedProjectAction(@JsonProperty("changeRequesId") ChangeRequestId changeRequestId,
+public record MergeUploadedProjectAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
                                          @JsonProperty("projectId") ProjectId projectId,
                                          @JsonProperty("documentId") DocumentId uploadedDocumentId,
                                          @JsonProperty("commitMessage") String commitMessage) implements ProjectAction<MergeUploadedProjectResult>, ContentChangeRequest {

--- a/src/main/java/edu/stanford/protege/webprotege/merge_add/ExistingOntologyMergeAddAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/merge_add/ExistingOntologyMergeAddAction.java
@@ -13,14 +13,14 @@ import java.util.List;
 
 
 
-@JsonTypeName("webprotege.ontologies.MergeOntologies")
+@JsonTypeName("webprotege.ontologies.ExistingOntologyMergeAdd")
 public record ExistingOntologyMergeAddAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
                                              @JsonProperty("projectId") ProjectId projectId,
                                              @JsonProperty("documentId") DocumentId documentId,
                                              @JsonProperty("selectedOntologies") List<OWLOntologyID> selectedOntologies,
                                              @JsonProperty("targetOntology") OWLOntologyID targetOntology) implements ProjectAction<ExistingOntologyMergeAddResult>, ContentChangeRequest {
 
-    public static final String CHANNEL = "webprotege.ontologies.MergeOntologies";
+    public static final String CHANNEL = "webprotege.ontologies.ExistingOntologyMergeAdd";
 
     @Override
     public String getChannel() {

--- a/src/main/java/edu/stanford/protege/webprotege/merge_add/ExistingOntologyMergeAddResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/merge_add/ExistingOntologyMergeAddResult.java
@@ -5,7 +5,7 @@ import edu.stanford.protege.webprotege.dispatch.Result;
 
 
 
-@JsonTypeName("webprotege.ontologies.MergeOntologies")
+@JsonTypeName("webprotege.ontologies.ExistingOntologyMergeAdd")
 public record ExistingOntologyMergeAddResult() implements Result {
 
 }

--- a/src/main/java/edu/stanford/protege/webprotege/ontology/GetRootOntologyIdResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/ontology/GetRootOntologyIdResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.ontology;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.Result;
@@ -14,7 +15,7 @@ import org.semanticweb.owlapi.model.OWLOntologyID;
 
 
 @JsonTypeName("webprotege.ontologies.GetRootOntologyId")
-public record GetRootOntologyIdResult(ProjectId projectId,
-                                      OWLOntologyID rootOntologyId) implements Result {
+public record GetRootOntologyIdResult(@JsonProperty("projectId") ProjectId projectId,
+                                      @JsonProperty("rootOntologyId") OWLOntologyID rootOntologyId) implements Result {
 
 }

--- a/src/main/java/edu/stanford/protege/webprotege/permissions/PermissionsChangedEvent.java
+++ b/src/main/java/edu/stanford/protege/webprotege/permissions/PermissionsChangedEvent.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.permissions;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.EventId;
 import edu.stanford.protege.webprotege.common.ProjectEvent;
@@ -16,8 +17,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * An event that is fired when the permissions for a project change.
  */
 @JsonTypeName("webprotege.events.projects.PermissionsChanged")
-public record PermissionsChangedEvent(EventId eventId,
-                                      ProjectId projectId) implements ProjectEvent {
+public record PermissionsChangedEvent(@JsonProperty("eventId") EventId eventId,
+                                      @JsonProperty("projectId") ProjectId projectId) implements ProjectEvent {
 
     public static final String CHANNEL = "webprotege.events.projects.PermissionsChanged";
 

--- a/src/main/java/edu/stanford/protege/webprotege/perspective/ResetPerspectivesAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/perspective/ResetPerspectivesAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.perspective;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ChangeRequest;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
@@ -14,8 +15,8 @@ import edu.stanford.protege.webprotege.dispatch.ProjectAction;
 
 
 @JsonTypeName("webprotege.perspectives.ResetPerspectives")
-public record ResetPerspectivesAction(ChangeRequestId changeRequestId,
-                                      ProjectId projectId) implements ProjectAction<ResetPerspectivesResult>, ChangeRequest {
+public record ResetPerspectivesAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                      @JsonProperty("projectId") ProjectId projectId) implements ProjectAction<ResetPerspectivesResult>, ChangeRequest {
 
     public static final String CHANNEL = "webprotege.perspectives.ResetPerspectives";
 

--- a/src/main/java/edu/stanford/protege/webprotege/project/CreateNewProjectAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/project/CreateNewProjectAction.java
@@ -15,8 +15,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 21/02/15
  */
 @JsonTypeName("webprotege.projects.CreateNewProject")
-public record CreateNewProjectAction(ProjectId newProjectId,
-                                     NewProjectSettings newProjectSettings) implements Action<CreateNewProjectResult>, Request<CreateNewProjectResult> {
+public record CreateNewProjectAction(@JsonProperty("newProjectId") ProjectId newProjectId,
+                                     @JsonProperty("newProjectSettings") NewProjectSettings newProjectSettings) implements Action<CreateNewProjectResult>, Request<CreateNewProjectResult> {
 
     public static final String CHANNEL = "webprotege.projects.CreateNewProject";
 

--- a/src/main/java/edu/stanford/protege/webprotege/project/SetProjectPrefixDeclarationsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/project/SetProjectPrefixDeclarationsAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.project;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ChangeRequest;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
@@ -17,9 +18,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 1 Mar 2018
  */
 @JsonTypeName("webprotege.projects.SetProjectPrefixDeclarations")
-public record SetProjectPrefixDeclarationsAction(@Nonnull ChangeRequestId changeRequestId,
-                                                 @Nonnull ProjectId projectId,
-                                                 @Nonnull List<PrefixDeclaration> prefixDeclarations) implements ProjectAction<SetProjectPrefixDeclarationsResult>, ChangeRequest {
+public record SetProjectPrefixDeclarationsAction(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                                 @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                                 @JsonProperty("prefixDeclarations") @Nonnull List<PrefixDeclaration> prefixDeclarations) implements ProjectAction<SetProjectPrefixDeclarationsResult>, ChangeRequest {
 
     public static final String CHANNEL = "webprotege.projects.SetProjectPrefixDeclarations";
 

--- a/src/main/java/edu/stanford/protege/webprotege/projectsettings/SetProjectSettingsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/projectsettings/SetProjectSettingsAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.projectsettings;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ChangeRequest;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
@@ -14,9 +15,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 25/11/14
  */
 @JsonTypeName("webprotege.projects.SetProjectSettings")
-public record SetProjectSettingsAction(ChangeRequestId changeRequestId,
-                                       ProjectId projectId,
-                                       ProjectSettings settings) implements ProjectAction<SetProjectSettingsResult>, ChangeRequest {
+public record SetProjectSettingsAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                       @JsonProperty("projectId") ProjectId projectId,
+                                       @JsonProperty("settings") ProjectSettings settings) implements ProjectAction<SetProjectSettingsResult>, ChangeRequest {
 
     public static final String CHANNEL = "webprotege.projects.SetProjectSettings";
 

--- a/src/main/java/edu/stanford/protege/webprotege/projectsettings/SetProjectSettingsResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/projectsettings/SetProjectSettingsResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.projectsettings;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.dispatch.Result;
 
@@ -11,7 +12,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 25/11/14
  */
 @JsonTypeName("webprotege.projects.SetProjectSettings")
-public record SetProjectSettingsResult(ProjectSettings settings) implements Result {
+public record SetProjectSettingsResult(@JsonProperty("settings") ProjectSettings settings) implements Result {
 
     public SetProjectSettingsResult(ProjectSettings settings) {
         this.settings = checkNotNull(settings);

--- a/src/main/java/edu/stanford/protege/webprotege/revision/GetHeadRevisionNumberResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/revision/GetHeadRevisionNumberResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.revision;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ProjectId;
 import edu.stanford.protege.webprotege.dispatch.Result;
@@ -12,8 +13,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 21/02/15
  */
 @JsonTypeName("webprotege.history.GetHeadRevisionNumber")
-public record GetHeadRevisionNumberResult(ProjectId projectId,
-                                         RevisionNumber revisionNumber) implements Result {
+public record GetHeadRevisionNumberResult(@JsonProperty("projectId") ProjectId projectId,
+                                          @JsonProperty("revisionNumber") RevisionNumber revisionNumber) implements Result {
 
     public GetHeadRevisionNumberResult(ProjectId projectId, RevisionNumber revisionNumber) {
         this.projectId = checkNotNull(projectId);

--- a/src/main/java/edu/stanford/protege/webprotege/revision/GetRevisionSummariesAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/revision/GetRevisionSummariesAction.java
@@ -16,8 +16,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 21/02/15
  */
 @JsonTypeName("webprotege.history.GetRevisionSummaries")
-public record GetRevisionSummariesAction(@JsonProperty(required = true) ProjectId projectId,
-                                         PageRequest pageRequest) implements ProjectAction<GetRevisionSummariesResult> {
+public record GetRevisionSummariesAction(@JsonProperty(value = "projectId", required = true) ProjectId projectId,
+                                         @JsonProperty("pageRequest") PageRequest pageRequest) implements ProjectAction<GetRevisionSummariesResult> {
 
     public static final String CHANNEL = "webprotege.history.GetRevisionSummaries";
 

--- a/src/main/java/edu/stanford/protege/webprotege/sharing/GetProjectSharingSettingsResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/sharing/GetProjectSharingSettingsResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.sharing;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.dispatch.Result;
 
@@ -11,7 +12,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 07/02/15
  */
 @JsonTypeName("webprotege.projects.GetProjectSharingSettings")
-public record GetProjectSharingSettingsResult(ProjectSharingSettings settings) implements Result {
+public record GetProjectSharingSettingsResult(@JsonProperty("settings") ProjectSharingSettings settings) implements Result {
 
     public GetProjectSharingSettingsResult(ProjectSharingSettings settings) {
         this.settings = checkNotNull(settings);

--- a/src/main/java/edu/stanford/protege/webprotege/tag/AddProjectTagAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/tag/AddProjectTagAction.java
@@ -19,12 +19,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 18 Mar 2018
  */
 @JsonTypeName("webprotege.tags.AddProjectTag")
-public record AddProjectTagAction(ChangeRequestId changeRequestId,
-                                  ProjectId projectId,
-                                  String label,
-                                  String description,
-                                  Color color,
-                                  Color backgroundColor) implements ProjectAction<AddProjectTagResult>, ChangeRequest {
+public record AddProjectTagAction(@JsonProperty("changeRequestId") ChangeRequestId changeRequestId,
+                                  @JsonProperty("projectId") ProjectId projectId,
+                                  @JsonProperty("label") String label,
+                                  @JsonProperty("description") String description,
+                                  @JsonProperty("color") Color color,
+                                  @JsonProperty("backgroundColor") Color backgroundColor) implements ProjectAction<AddProjectTagResult>, ChangeRequest {
 
     public static final String CHANNEL = "webprotege.tags.AddProjectTag";
 

--- a/src/main/java/edu/stanford/protege/webprotege/tag/EntityTagsChangedEvent.java
+++ b/src/main/java/edu/stanford/protege/webprotege/tag/EntityTagsChangedEvent.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.tag;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.EventId;
 import edu.stanford.protege.webprotege.common.ProjectEvent;
@@ -18,10 +19,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 22 Mar 2018
  */
 @JsonTypeName("webprotege.events.tags.EntityTagsChanged")
-public record EntityTagsChangedEvent(@Nonnull EventId eventId,
-                                     @Nonnull ProjectId projectId,
-                                    @Nonnull OWLEntity entity,
-                                    @Nonnull Collection<Tag> tags) implements ProjectEvent {
+public record EntityTagsChangedEvent(@JsonProperty("eventId") @Nonnull EventId eventId,
+                                     @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                     @JsonProperty("entity") @Nonnull OWLEntity entity,
+                                     @JsonProperty("tags") @Nonnull Collection<Tag> tags) implements ProjectEvent {
 
     public static final String CHANNEL = "webprotege.events.tags.EntityTagsChanged";
 

--- a/src/main/java/edu/stanford/protege/webprotege/tag/ProjectTagsChangedEvent.java
+++ b/src/main/java/edu/stanford/protege/webprotege/tag/ProjectTagsChangedEvent.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.tag;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.EventId;
 import edu.stanford.protege.webprotege.common.ProjectEvent;
@@ -14,9 +15,9 @@ import java.util.Collection;
  * 26 Mar 2018
  */
 @JsonTypeName("webprotege.events.tags.ProjectTagsChanged")
-public record ProjectTagsChangedEvent(@Nonnull EventId eventId,
-                                      @Nonnull ProjectId projectId,
-                                      @Nonnull Collection<Tag> projectTags) implements ProjectEvent {
+public record ProjectTagsChangedEvent(@JsonProperty("eventId") @Nonnull EventId eventId,
+                                      @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                      @JsonProperty("projectTags") @Nonnull Collection<Tag> projectTags) implements ProjectEvent {
 
     public static final String CHANNEL = "webprotege.events.tags.ProjectTagsChanged";
 

--- a/src/main/java/edu/stanford/protege/webprotege/tag/UpdateEntityTagsAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/tag/UpdateEntityTagsAction.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.tag;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.ChangeRequest;
 import edu.stanford.protege.webprotege.common.ChangeRequestId;
@@ -18,11 +19,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * 21 Mar 2018
  */
 @JsonTypeName("webprotege.tags.UpdateEntityTags")
-public record UpdateEntityTagsAction(@Nonnull ChangeRequestId changeRequestId,
-                                     @Nonnull ProjectId projectId,
-                                     @Nonnull OWLEntity entity,
-                                     @Nonnull Set<TagId> fromTagIds,
-                                     @Nonnull Set<TagId> toTagIds) implements ProjectAction<UpdateEntityTagsResult>, ChangeRequest {
+public record UpdateEntityTagsAction(@JsonProperty("changeRequestId") @Nonnull ChangeRequestId changeRequestId,
+                                     @JsonProperty("projectId") @Nonnull ProjectId projectId,
+                                     @JsonProperty("entity") @Nonnull OWLEntity entity,
+                                     @JsonProperty("fromTagIds") @Nonnull Set<TagId> fromTagIds,
+                                     @JsonProperty("toTagIds") @Nonnull Set<TagId> toTagIds) implements ProjectAction<UpdateEntityTagsResult>, ChangeRequest {
 
     public static final String CHANNEL = "webprotege.tags.UpdateEntityTags";
 

--- a/src/main/java/edu/stanford/protege/webprotege/usage/GetEntityUsageAction.java
+++ b/src/main/java/edu/stanford/protege/webprotege/usage/GetEntityUsageAction.java
@@ -1,6 +1,7 @@
 package edu.stanford.protege.webprotege.usage;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.PageRequest;
@@ -22,12 +23,16 @@ import java.util.Optional;
 
 @JsonTypeName("webprotege.entities.GetEntityUsage")
 @JsonClassDescription("Requests the entity usage for the specified entity.  The usage is the set of OWL axioms that mention the entity in their signature.")
-public record GetEntityUsageAction(@JsonPropertyDescription("The entity whose usage will be returned")
+public record GetEntityUsageAction(@JsonProperty("subject")
+                                   @JsonPropertyDescription("The entity whose usage will be returned")
                                    OWLEntity subject,
+                                   @JsonProperty("projectId")
                                    @JsonPropertyDescription("The project id in which the entity is used")
                                    ProjectId projectId,
+                                   @JsonProperty("usageFilter")
                                    @JsonPropertyDescription("The usage filter that specifies they types of axioms to be retrieved etc.")
                                    @Nullable UsageFilter usageFilter,
+                                   @JsonProperty("pageRequest")
                                    @Nonnull
                                    PageRequest pageRequest) implements ProjectAction<GetEntityUsageResult> {
 

--- a/src/main/java/edu/stanford/protege/webprotege/viz/GetProjectEntityGraphDefaultEdgeCriteriaResult.java
+++ b/src/main/java/edu/stanford/protege/webprotege/viz/GetProjectEntityGraphDefaultEdgeCriteriaResult.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.viz;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.collect.ImmutableList;
 import edu.stanford.protege.webprotege.dispatch.Result;
@@ -10,6 +11,6 @@ import edu.stanford.protege.webprotege.dispatch.Result;
  * 2019-12-07
  */
 @JsonTypeName("webprotege.graphs.GetProjectEntityGraphDefaultEdgeCriteria")
-public record GetProjectEntityGraphDefaultEdgeCriteriaResult(ImmutableList<EdgeCriteria> edgeCriteria) implements Result {
+public record GetProjectEntityGraphDefaultEdgeCriteriaResult(@JsonProperty("edgeCriteria") ImmutableList<EdgeCriteria> edgeCriteria) implements Result {
 
 }

--- a/src/main/java/edu/stanford/protege/webprotege/watches/WatchAddedEvent.java
+++ b/src/main/java/edu/stanford/protege/webprotege/watches/WatchAddedEvent.java
@@ -1,6 +1,7 @@
 package edu.stanford.protege.webprotege.watches;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.EventId;
 import edu.stanford.protege.webprotege.common.ProjectEvent;
@@ -13,9 +14,9 @@ import edu.stanford.protege.webprotege.common.ProjectId;
  * Date: 21/03/2013
  */
 @JsonTypeName("webprotege.events.watches.WatchAdded")
-public record WatchAddedEvent(EventId eventId,
-                              ProjectId projectId,
-                              Watch watch) implements ProjectEvent {
+public record WatchAddedEvent(@JsonProperty("eventId") EventId eventId,
+                              @JsonProperty("projectId") ProjectId projectId,
+                              @JsonProperty("watch") Watch watch) implements ProjectEvent {
 
     public static final String CHANNEL = "webprotege.events.watches.WatchAdded";
 

--- a/src/main/java/edu/stanford/protege/webprotege/watches/WatchRemovedEvent.java
+++ b/src/main/java/edu/stanford/protege/webprotege/watches/WatchRemovedEvent.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.watches;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import edu.stanford.protege.webprotege.common.EventId;
 import edu.stanford.protege.webprotege.common.ProjectEvent;
@@ -12,9 +13,9 @@ import edu.stanford.protege.webprotege.common.ProjectId;
  * Date: 21/03/2013
  */
 @JsonTypeName("webprotege.events.watches.WatchRemoved")
-public record WatchRemovedEvent(EventId eventId,
-                                ProjectId projectId,
-                                Watch watch) implements ProjectEvent {
+public record WatchRemovedEvent(@JsonProperty("eventId") EventId eventId,
+                                @JsonProperty("projectId") ProjectId projectId,
+                                @JsonProperty("watch") Watch watch) implements ProjectEvent {
 
     public static final String CHANNEL = "webprotege.events.watches.WatchRemoved";
 


### PR DESCRIPTION
Backend half of the coordinated pair for #53. The companion client-side changes live in [webprotege-gwt-ui#274](https://github.com/protegeproject/webprotege-gwt-ui/pull/274); the two should land together.

## What's changing

The backend exchanges messages with the gwt-ui client as JSON. Each field has a name on the wire — but for a chunk of our DTOs, that name was never written down explicitly. Jackson was happy to *infer* the JSON name from the Java field name, which worked fine until someone renamed a Java field (the wire silently broke) or until the two repos drifted apart on what name to use (the field silently dropped).

This PR locks down the wire names on the backend side. Concretely:

- **Two fields had the wrong name and are renamed.** Both were special cases of `changeRequestId` — one had a typo (`changeRequesId`), and one used a completely different name (`contentChangeRequest`) than every other class that carries the same field. Renamed so the client and backend agree. See  [d93ef1e](https://github.com/protegeproject/webprotege-backend-api/commit/d93ef1e).

- **The remaining records get an explicit `@JsonProperty("…")` on every component.** This doesn't change the wire today — it just tells the compiler and the next reader exactly what the JSON name is supposed to be, so a future Java rename can't silently break the contract. Issue 52 did this for one bucket of classes; this PR finishes the rest (the Actions, Results, and Events that were skipped because they were already known to disagree with the client). See [ac099c6](https://github.com/protegeproject/webprotege-backend-api/commit/ac099c6), [e538e6f](https://github.com/protegeproject/webprotege-backend-api/commit/e538e6f), [f9d9d7b](https://github.com/protegeproject/webprotege-backend-api/commit/f9d9d7b), [f9b4b1d](https://github.com/protegeproject/webprotege-backend-api/commit/f9b4b1d), [99b2439](https://github.com/protegeproject/webprotege-backend-api/commit/99b2439).

## Why now

Until the companion PR in `webprotege-gwt-ui` lands, these annotations are a pure cleanup — they describe what we already do. Once the client PR lands, the two sides finally agree on the field set for every message they exchange. That fixes a quiet category of bugs where caller-supplied data (change-request ids, page requests, project ids, event ids) was being dropped on the wire and silently regenerated server-side.

## Test plan

- [x] `mvn -DskipTests compile` succeeds.
- [x] Existing serialization tests pass.
- [x] Companion PR webprotege-gwt-ui#274 builds and passes its tests.

## Crosslink
https://github.com/protegeproject/webprotege-gwt-ui/pull/274